### PR TITLE
Run Hello.scala in CI

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -18,5 +18,7 @@ jobs:
       with:
         java-version: '11'
         distribution: 'temurin'
-    - name: Run tests
-      run: sbt test
+    - name: Compile
+      run: scalac Hello.scala
+    - name: Run
+      run: scala Hello


### PR DESCRIPTION
This commit modifies the GitHub Actions workflow for Scala.

The previous workflow was configured to run `sbt test`, but there was no sbt configuration in the repository.

This change replaces the `sbt test` step with two new steps:
1.  Compile `Hello.scala` using `scalac`.
2.  Run the compiled `Hello` class using `scala`.

This allows the CI to successfully execute the `Hello.scala` program.